### PR TITLE
Add temporary fix for abrupt thread termination

### DIFF
--- a/electrum/plugins/cosigner_pool/qt.py
+++ b/electrum/plugins/cosigner_pool/qt.py
@@ -191,6 +191,7 @@ class Plugin(BasePlugin):
             task = lambda: server.put(_hash, message)
             msg = _('Sending transaction to cosigning pool...')
             WaitingDialog(window, msg, task, on_success, on_failure)
+            time.sleep(.5)
 
     def on_receive(self, keyhash, message):
         self.print_error("signal arrived for", keyhash)


### PR DESCRIPTION
Sending transactions to cosigner pool generates 'n-1' number of task-threads in respect to number of cosigners in multi-signature wallet. 

Creating multiple threads in rapid succession raises a `**ResponseNotReady**` exception, and produces the following stack trace for each thread experiencing the problem:

`Traceback (most recent call last):`
`  File "/electrum-civx/electrum/gui/qt/util.py", line 661, in run`
`    result = task.task()`
`  File "/electrum-civx/electrum/plugins/cosigner_pool/qt.py", line 196, in <lambda>`
`    task = lambda: server.put(_hash, message)`
`  File "/usr/lib/python3.7/xmlrpc/client.py", line 1112, in __call__`
`    return self.__send(self.__name, args)`
`  File "/usr/lib/python3.7/xmlrpc/client.py", line 1452, in __request`
`    verbose=self.__verbose`
`  File "/usr/lib/python3.7/xmlrpc/client.py", line 1154, in request`
`    return self.single_request(host, handler, request_body, verbose)`
`  File "/usr/lib/python3.7/xmlrpc/client.py", line 1167, in single_request`
`    resp = http_conn.getresponse()`
`  File "/usr/lib/python3.7/http/client.py", line 1311, in getresponse`
`    raise ResponseNotReady(self.__state)`
`http.client.ResponseNotReady: Idle`

Also produces the following error: `QThread: Destroyed while thread is still running`.

Allowing time between thread creation seems to prevent the error but should not be seen as a permanent solution. 