### PR TITLE
Implement plugin hot load

### DIFF
--- a/electrum/plugins/labels/qt.py
+++ b/electrum/plugins/labels/qt.py
@@ -91,3 +91,4 @@ class Plugin(LabelsPlugin):
         if not self.wallets:
             wallet = window.wallet
             self.load_wallet(wallet, window)
+            self.pull(wallet, True)

--- a/electrum/plugins/labels/qt.py
+++ b/electrum/plugins/labels/qt.py
@@ -77,3 +77,17 @@ class Plugin(LabelsPlugin):
         except TypeError:
             pass  # 'method' object is not connected
         self.stop_wallet(window.wallet)
+
+    @hook
+    def init_qt(self, gui):
+        for window in gui.windows:
+            self.on_new_window(window)
+
+    @hook
+    def on_new_window(self, window):
+        self.update(window)
+
+    def update(self, window):
+        if not self.wallets:
+            wallet = window.wallet
+            self.load_wallet(wallet, window)


### PR DESCRIPTION
_'load_wallet'_ hook does not run when LabelSync plugin is enabled as wallet has already been loaded. _'init_qt'_ hook is used to check whether wallet has been loaded, and then runs load wallet hook instead. See `# FIXME     `.
```    
    @hook
    def load_wallet(self, wallet, window):
        # FIXME if the user just enabled the plugin, this hook won't be called
        # as the wallet is already loaded, and hence the plugin will be in
        # a non-functional state for that window
        self.obj.labels_changed_signal.connect(window.update_tabs)
        self.start_wallet(wallet)

    @hook
    def init_qt(self, gui):
        for window in gui.windows:
            self.on_new_window(window)

    @hook
    def on_new_window(self, window):
        self.update(window)

    def update(self, window):
        if not self.wallets:
            wallet = window.wallet
            self.load_wallet(wallet, window)
```