### PR TITLE
Fix for feature/crashpick

### DIFF
--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -54,7 +54,6 @@ from .util import (MessageBoxMixin, read_QIcon, Buttons, CopyButton,
 
 SAVE_BUTTON_ENABLED_TOOLTIP = _("Save transaction offline")
 SAVE_BUTTON_DISABLED_TOOLTIP = _("Please sign this transaction in order to save it")
-DURATION_INT = 60 * 10 
 
 dialogs = []  # Otherwise python randomly garbage collects the dialogs...
 
@@ -388,6 +387,8 @@ class TxDialog(QDialog, MessageBoxMixin):
             cursor.insertBlock()
         vbox.addWidget(o_text)
 
+DURATION_INT = 60 * 10 
+
 class TxDialogTimeout(TxDialog):
     
     def __init__(self, tx, parent, desc, prompt_if_unsaved):
@@ -427,7 +428,7 @@ class TxDialogTimeout(TxDialog):
                     self.locks[_hash] = server.get(_hash+'_lock')
                 else:
                     self.cosigner_list.add(_hash)
-
+                    
 
         # if the wallet can populate the inputs with more info, do it now.
         # as a result, e.g. we might learn an imported address tx is segwit,
@@ -510,13 +511,10 @@ class TxDialogTimeout(TxDialog):
         for _hash, expire in self.locks.items():
             if expire:
                 self.time_left_int = int((DURATION_INT - (int(server.get_current_time()) - int(expire))))
-
-        self.timer_start()
+                self.timer_start()
         self.update()
 
     def timer_start(self):
-        #self.time_left_int = DURATION_INT
-
         self.my_qtimer = QTimer(self)
         self.my_qtimer.timeout.connect(self.timer_timeout)
         self.my_qtimer.start(1000)

--- a/electrum/gui/qt/transaction_wait_dialog.py
+++ b/electrum/gui/qt/transaction_wait_dialog.py
@@ -162,6 +162,14 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
         self.update()
 
     def closeEvent(self, event):
+        if (self.time_left_int == 0):
+            event.accept()
+            try:
+                dialogs.remove(self)
+                return
+            except ValueError:
+                pass  # was not in list already
+
         if (self.prompt_if_unsaved and not self.saved
                 and not self.question(_('Are you sure you want to close the waiting dialog?') +'\n'+
                                     _('Please restart your wallet to display again.'), title=_("Warning"))):

--- a/electrum/gui/qt/transaction_wait_dialog.py
+++ b/electrum/gui/qt/transaction_wait_dialog.py
@@ -105,7 +105,12 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
 
         vbox = QVBoxLayout()
         self.setLayout(vbox)
-
+        self.warning = QLabel()
+        vbox.addWidget(self.warning)
+        warning_text = (_('A transaction witht the following information is currently being signed')+'\n'+
+                    _('by a cosigner. A notification will appear within 30 seconds of either signing') +'\n'+
+                    _('or the transaction window expiring. Thank you for being patient.'))
+        self.warning.setText(warning_text)
         self.tx_desc = QLabel()
         vbox.addWidget(self.tx_desc)
         self.status_label = QLabel()

--- a/electrum/gui/qt/transaction_wait_dialog.py
+++ b/electrum/gui/qt/transaction_wait_dialog.py
@@ -167,7 +167,7 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
         self.update()
 
     def closeEvent(self, event):
-        if (self.time_left_int == 0):
+        if (self.time_left_int <= 0):
             event.accept()
             try:
                 dialogs.remove(self)
@@ -192,6 +192,16 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
         self.close()
 
     def update(self):
+        if self.time_left_int % 10 == 0:
+            lock_present = False
+            for _hash in self.cosigner_list:
+                lock = server.get(_hash+'_lock')
+                if lock:
+                    lock_present = True
+            if not lock_present:
+                self.time_left_int = 0
+                self.close()
+
         desc = None
         base_unit = self.main_window.base_unit()
         format_amount = self.main_window.format_amount

--- a/electrum/gui/qt/transaction_wait_dialog.py
+++ b/electrum/gui/qt/transaction_wait_dialog.py
@@ -106,10 +106,10 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
         vbox = QVBoxLayout()
         self.setLayout(vbox)
 
-        vbox.addWidget(QLabel(_("Transaction ID:")))
-        self.tx_hash_e  = ButtonsLineEdit()
-        self.tx_hash_e.setReadOnly(True)
-        vbox.addWidget(self.tx_hash_e)
+        # vbox.addWidget(QLabel(_("Transaction ID:")))
+        # self.tx_hash_e  = ButtonsLineEdit()
+        # self.tx_hash_e.setReadOnly(True)
+        # vbox.addWidget(self.tx_hash_e)
         self.tx_desc = QLabel()
         vbox.addWidget(self.tx_desc)
         self.status_label = QLabel()
@@ -144,7 +144,7 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
             if expire:
                 # Set time left to desired duration 
                 self.time_left_int = int(DURATION_INT - (int(server.get_current_time()) - int(expire)))
-
+        
         self.timer_start()
         self.update()
 
@@ -190,7 +190,7 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
         size = self.tx.estimated_size()
         can_sign = not self.tx.is_complete() and \
             (self.wallet.can_sign(self.tx) or bool(self.main_window.tx_external_keypairs))
-        self.tx_hash_e.setText(tx_hash or _('Unknown'))
+        # self.tx_hash_e.setText(tx_hash or _('Unknown'))
         if desc is None:
             self.tx_desc.hide()
         else:

--- a/electrum/gui/qt/transaction_wait_dialog.py
+++ b/electrum/gui/qt/transaction_wait_dialog.py
@@ -100,16 +100,12 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
                     self.cosigner_list.add(_hash)
                     self.locks[_hash] = server.get(_hash+'_lock')
 
-        self.setMinimumWidth(950)
+        self.setMinimumWidth(200)
         self.setWindowTitle(_("Information"))
 
         vbox = QVBoxLayout()
         self.setLayout(vbox)
 
-        # vbox.addWidget(QLabel(_("Transaction ID:")))
-        # self.tx_hash_e  = ButtonsLineEdit()
-        # self.tx_hash_e.setReadOnly(True)
-        # vbox.addWidget(self.tx_hash_e)
         self.tx_desc = QLabel()
         vbox.addWidget(self.tx_desc)
         self.status_label = QLabel()
@@ -190,7 +186,6 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
         size = self.tx.estimated_size()
         can_sign = not self.tx.is_complete() and \
             (self.wallet.can_sign(self.tx) or bool(self.main_window.tx_external_keypairs))
-        # self.tx_hash_e.setText(tx_hash or _('Unknown'))
         if desc is None:
             self.tx_desc.hide()
         else:

--- a/electrum/gui/qt/transaction_wait_dialog.py
+++ b/electrum/gui/qt/transaction_wait_dialog.py
@@ -107,9 +107,9 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
         self.setLayout(vbox)
         self.warning = QLabel()
         vbox.addWidget(self.warning)
-        warning_text = (_('A transaction witht the following information is currently being signed')+'\n'+
+        warning_text = (_('A transaction with the following information is currently being signed')+'\n'+
                     _('by a cosigner. A notification will appear within 30 seconds of either signing') +'\n'+
-                    _('or the transaction window expiring. Thank you for being patient.'))
+                    _('or the transaction window expiring.'))
         self.warning.setText(warning_text)
         self.tx_desc = QLabel()
         vbox.addWidget(self.tx_desc)

--- a/electrum/plugins/cosigner_pool/qt.py
+++ b/electrum/plugins/cosigner_pool/qt.py
@@ -234,7 +234,7 @@ class Plugin(BasePlugin):
 
         if self.suppress_notifications:
             for window, xpub, K, _hash in self.cosigner_list:
-                if server.get(_hash+'lock'):
+                if server.get(_hash+'_lock'):
                     return
             self.suppress_notifications = False
 

--- a/electrum/plugins/cosigner_pool/qt.py
+++ b/electrum/plugins/cosigner_pool/qt.py
@@ -75,7 +75,6 @@ class Listener(util.DaemonThread):
             return
         server.put(_hash+'_pick', 'True')
         server.put(_hash+'_shutdown', 'down')
-        self.locks.clear()
 
     def run(self):
         while self.running:

--- a/electrum/plugins/cosigner_pool/qt.py
+++ b/electrum/plugins/cosigner_pool/qt.py
@@ -111,7 +111,6 @@ class Plugin(BasePlugin):
         self.obj.cosigner_receive_signal.connect(self.on_receive)
         self.keys = []
         self.cosigner_list = []
-        self.locks = {}
         self.suppress_notifications = False
 
 
@@ -233,12 +232,9 @@ class Plugin(BasePlugin):
 
         WAIT_TIME = 10 * 60
 
-        for window, xpub, K, _hash in self.cosigner_list:
-            self.locks[_hash] = server.get(_hash+'_lock')
-
         if self.suppress_notifications:
-            for _hash, expire in self.locks.items():
-                if expire:
+            for window, xpub, K, _hash in self.cosigner_list:
+                if server.get(_hash+'lock'):
                     return
             self.suppress_notifications = False
 
@@ -292,7 +288,8 @@ class Plugin(BasePlugin):
             return '{:02d}:{:02d}'.format(mins, secs)
 
         # check if lock has been placed for any wallets
-        for _hash, expire in self.locks.items():
+        for window, xpub, K, _hash in self.cosigner_list:
+            expire = server.get(_hash+'_lock')
             if expire:
                 # set pick back to true if user lock is present
                 server.put(keyhash+'_pick', 'True')


### PR DESCRIPTION
- Users can now reliably resume cosigning after a crash, and the updated time will be displayed in the 'Time Left' field
