### PR TITLE
Make minor fixes to 3.3.8-alpha

### DIFF
--- a/electrum/gui/qt/transaction_dialog.py
+++ b/electrum/gui/qt/transaction_dialog.py
@@ -542,6 +542,7 @@ class TxDialogTimeout(TxDialog):
         hbox.addLayout(Buttons(*self.buttons))
         vbox.addLayout(hbox)
 
+        self.time_left_int = int(DURATION_INT)
         for _hash, expire in self.locks.items():
             if expire:
                 self.time_left_int = int((DURATION_INT - (int(server.get_current_time()) - int(expire))))

--- a/electrum/gui/qt/transaction_wait_dialog.py
+++ b/electrum/gui/qt/transaction_wait_dialog.py
@@ -149,6 +149,7 @@ class TimeoutWaitDialog(QDialog, MessageBoxMixin):
         hbox.addLayout(Buttons(*self.buttons))
         vbox.addLayout(hbox)
 
+        self.time_left_int = int(DURATION_INT)
         for _hash, expire in self.locks.items():
             if expire:
                 # Set time left to desired duration 

--- a/electrum/plugins/cosigner_pool/qt.py
+++ b/electrum/plugins/cosigner_pool/qt.py
@@ -88,6 +88,9 @@ class Listener(util.DaemonThread):
                 except CannotSendRequest:
                     self.logger.info("cannot contact cosigner pool")
                     continue
+                except Exception as e:
+                    self.logger.info(e)
+                    continue
 
                 if pick == 'False' or signed == 'True':
                     continue

--- a/electrum/plugins/cosigner_pool/qt.py
+++ b/electrum/plugins/cosigner_pool/qt.py
@@ -81,7 +81,8 @@ class Listener(util.DaemonThread):
             for keyhash in self.keyhashes:
                 try:
                     if server.get(keyhash+'_name') == None:
-                        server.put(keyhash+'_name', keyhash)
+                        keyhash_concise = keyhash[0:10]+'...'+keyhash[-1:-5:-1]
+                        server.put(keyhash+'_name', keyhash_concise)
                     pick = server.get(keyhash+'_pick')
                     signed = server.get(keyhash+'_signed')
                 except CannotSendRequest:

--- a/electrum/plugins/labels/qt.py
+++ b/electrum/plugins/labels/qt.py
@@ -26,27 +26,14 @@ class Plugin(LabelsPlugin):
         return True
 
     def settings_widget(self, window):
-        return EnterButton(_('Settings'),
-                           partial(self.settings_dialog, window))
 
-    def settings_dialog(self, window):
         wallet = window.parent().wallet
         d = WindowModalDialog(window, _("Label Settings"))
-        hbox = QHBoxLayout()
-        hbox.addWidget(QLabel("Label sync options:"))
-        synchronize = ThreadedButton("Synchronize",
+
+        return ThreadedButton("Synchronize",
                             partial(self.synchronize, wallet, True),
                             partial(self.done_processing_success, d),
                             partial(self.done_processing_error, d))
-        vbox = QVBoxLayout()
-        vbox.addWidget(synchronize)
-        hbox.addLayout(vbox)
-        vbox = QVBoxLayout(d)
-        vbox.addLayout(hbox)
-        vbox.addSpacing(20)
-        vbox.addLayout(Buttons(OkButton(d)))
-        return bool(d.exec_())
-
 
     def synchronize(self, wallet, force):
         self.pull(wallet, force)


### PR DESCRIPTION
- Set default time_left_int of DURATION_INT
- Truncate keyhash for name display
- Catch generic case exceptions to limit the number of crash reports
- Replace 'Settings' button with 'Synchronize' 